### PR TITLE
simplification of mid variable calculation

### DIFF
--- a/Collection_of_Algorithms/Searches/BinarySearch.cpp
+++ b/Collection_of_Algorithms/Searches/BinarySearch.cpp
@@ -7,7 +7,7 @@ int binarySearch(int arr[], int l, int r, int ele)
 { 
    if (r >= l) 
    { 
-        int mid = l + (r - l)/2; 
+        int mid = (r + l)/2; 
   
         // If the element is found return mid  
         


### PR DESCRIPTION
Explanation for the simplification:
l + (r - l)/2 == (2*l + r - l)/2 == (r + l)/2
You can always get mid value of an interval [a,b] by doing (a+b)/2.
